### PR TITLE
added more integration WebMvc tests to cover TesAdapterController cla…

### DIFF
--- a/tes-adapter/build.gradle
+++ b/tes-adapter/build.gradle
@@ -14,6 +14,7 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
+apply plugin: 'jacoco'
 
 repositories {
     mavenCentral()

--- a/tes-adapter/src/main/java/com/epam/pipeline/tesadapter/controller/TesExceptionHandler.java
+++ b/tes-adapter/src/main/java/com/epam/pipeline/tesadapter/controller/TesExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.epam.pipeline.tesadapter.controller;
 
+import com.epam.pipeline.tesadapter.common.MessageHelper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -8,14 +10,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
 @Slf4j
-@RestControllerAdvice("com.epam.pipeline.tesadapter.controller")
+@RestControllerAdvice()
 public class TesExceptionHandler {
+
+    @Autowired
+    private MessageHelper messageHelper;
 
     @ExceptionHandler(Throwable.class)
     public final ResponseEntity<String> handleUncaughtException(final Throwable exception, final WebRequest
             request) {
-        log.error(exception.getMessage() + request.getDescription(true));
-        return new ResponseEntity<>(exception.getMessage() + request.getDescription(true),
-                HttpStatus.INTERNAL_SERVER_ERROR);
+        log.error(messageHelper.getMessage("logger.error", request.getDescription(true)), exception);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(exception.getMessage() + request.getDescription(true));
+
     }
 }

--- a/tes-adapter/src/main/java/com/epam/pipeline/tesadapter/service/TaskMapper.java
+++ b/tes-adapter/src/main/java/com/epam/pipeline/tesadapter/service/TaskMapper.java
@@ -127,7 +127,7 @@ public class TaskMapper {
 
     public TesExecutor getExecutorFromTesExecutorsList(List<TesExecutor> tesExecutors) {
         Assert.isTrue(tesExecutors.size() == ONLY_ONE, messageHelper.getMessage(
-                MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, EXECUTORS, tesExecutors));
+                MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, EXECUTORS));
         return tesExecutors.get(FIRST);
     }
 
@@ -160,7 +160,7 @@ public class TaskMapper {
 
     public Long getProperRegionIdInCloudRegionsByTesZone(List<String> zones) {
         Assert.isTrue(zones.size() == ONLY_ONE, messageHelper.getMessage(
-                MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, ZONES, zones));
+                MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, ZONES));
         return Optional.ofNullable(cloudPipelineAPIClient.loadAllRegions().stream().filter(
                 region -> region.getName().equalsIgnoreCase(zones.get(FIRST)))
                 .collect(Collectors.toList()).get(FIRST).getId()).orElseThrow(() ->

--- a/tes-adapter/src/main/java/com/epam/pipeline/tesadapter/service/TesTaskServiceImpl.java
+++ b/tes-adapter/src/main/java/com/epam/pipeline/tesadapter/service/TesTaskServiceImpl.java
@@ -122,7 +122,7 @@ public class TesTaskServiceImpl implements TesTaskService {
 
     private Long parseRunId(String id) {
         Assert.state(StringUtils.isNumeric(id),
-                messageHelper.getMessage(MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, "ID", id));
+                messageHelper.getMessage(MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, ID));
         return Long.parseLong(id);
     }
 

--- a/tes-adapter/src/main/resources/messages.properties
+++ b/tes-adapter/src/main/resources/messages.properties
@@ -5,4 +5,4 @@ error.parameter.required=Parameter ''{0}'' id required for ''{1}'' podId.
 
 #Parameters
 error.parameter.non.scalar.type=Unable to resolve parameter value ''{0}''. Reference value for field ''{1}'' is used as a parameter value.
-error.parameter.incompatible.content=Parameter (id ''{0}'') is not compatible with content ''{1}''.
+error.parameter.incompatible.content=Parameter (id ''{0}'') with undesirable content.

--- a/tes-adapter/src/test/java/com/epam/pipeline/tesadapter/app/TesAdapterControllerTest.java
+++ b/tes-adapter/src/test/java/com/epam/pipeline/tesadapter/app/TesAdapterControllerTest.java
@@ -1,22 +1,31 @@
 package com.epam.pipeline.tesadapter.app;
 
 
+import com.epam.pipeline.tesadapter.common.MessageConstants;
+import com.epam.pipeline.tesadapter.common.MessageHelper;
 import com.epam.pipeline.tesadapter.controller.TesAdapterController;
 import com.epam.pipeline.tesadapter.entity.TaskView;
 import com.epam.pipeline.tesadapter.entity.TesCancelTaskResponse;
 import com.epam.pipeline.tesadapter.entity.TesCreateTaskResponse;
+import com.epam.pipeline.tesadapter.entity.TesExecutor;
 import com.epam.pipeline.tesadapter.entity.TesListTasksResponse;
 import com.epam.pipeline.tesadapter.entity.TesServiceInfo;
 import com.epam.pipeline.tesadapter.entity.TesTask;
 import com.epam.pipeline.tesadapter.service.CloudPipelineAPIClient;
 import com.epam.pipeline.tesadapter.service.TesTaskServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -30,13 +39,28 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(TesAdapterController.class)
 @SuppressWarnings({"unused", "PMD.TooManyStaticImports"})
 public class TesAdapterControllerTest {
-    private static final String STUBBED_TASK_ID = "5";
+    private static final String DEFAULT_TASK_ID = "5";
     private static final String PAGE_TOKEN = "1";
     private static final String NAME_PREFIX = "pipeline";
+    private static final String EMPTY_INPUT = " ";
+    private static final String DEFAULT_COMMAND = "sleep 300";
+    private static final String DEFAULT_IMAGE =
+            "cp-docker-registry.default.svc.cluster.local:31443/library/centos:latest";
     private static final Long PAGE_SIZE = 20L;
     private static final TaskView DEFAULT_VIEW = TaskView.MINIMAL;
     private static final String STUBBED_SUBMIT_JSON_REQUEST = "{}";
     private static final String STUBBED_SUBMIT_JSON_RESPONSE = "{\"id\":\"5\"}";
+    private static final String CANCEL_REQUEST_DESCRIPTION = "uri=/v1/tasks/%20:cancel;client=127.0.0.1";
+    private static final String JSON_CONTENT_TYPE = "application/json";
+
+    @Value("${cloud.pipeline.service.name}")
+    private String nameOfService;
+
+    @Value("${cloud.pipeline.doc}")
+    private String doc;
+
+    @Autowired
+    private MessageHelper messageHelper;
 
     @Autowired
     private MockMvc mockMvc;
@@ -49,40 +73,56 @@ public class TesAdapterControllerTest {
 
     private TesCreateTaskResponse tesCreateTaskResponse = new TesCreateTaskResponse();
     private TesServiceInfo tesServiceInfo = new TesServiceInfo();
+    private TesTask tesTask = new TesTask();
+    private TesExecutor tesExecutor = new TesExecutor();
 
     @BeforeEach
     void setUp() {
 
-        when(tesTaskService.cancelTesTask(STUBBED_TASK_ID)).thenReturn(new TesCancelTaskResponse());
+        when(tesTaskService.cancelTesTask(DEFAULT_TASK_ID)).thenReturn(new TesCancelTaskResponse());
         when(tesTaskService.listTesTask(NAME_PREFIX, PAGE_SIZE, PAGE_TOKEN, DEFAULT_VIEW))
                 .thenReturn(mock(TesListTasksResponse.class));
         when(tesTaskService.getServiceInfo()).thenReturn(tesServiceInfo);
+        when(tesTaskService.getTesTask(DEFAULT_TASK_ID, DEFAULT_VIEW)).thenReturn(tesTask);
     }
 
     @Test
     void submitTesTaskWhenRequestingTesTaskBodyAndReturnId() throws Exception {
-        tesCreateTaskResponse.setId(STUBBED_TASK_ID);
+        tesCreateTaskResponse.setId(DEFAULT_TASK_ID);
         when(tesTaskService.submitTesTask(any(TesTask.class))).thenReturn(tesCreateTaskResponse);
-        this.mockMvc.perform(post("/v1/tasks").contentType("application/json")
+        this.mockMvc.perform(post("/v1/tasks").contentType(JSON_CONTENT_TYPE)
                 .content(STUBBED_SUBMIT_JSON_REQUEST))
-                .andDo(print()).andExpect(status().isOk()).andExpect(content().json(STUBBED_SUBMIT_JSON_RESPONSE));
+                .andDo(print()).andExpect(status().isOk()).andExpect(content()
+                .json(new ObjectMapper().writeValueAsString(tesCreateTaskResponse)));
     }
 
     @Test
     void expectIllegalArgExceptionWhenRunSubmitTesTasWithNullId() throws Exception {
-        TesTask tesTask = new TesTask();
         tesTask.setExecutors(null);
         when(tesTaskService.submitTesTask(tesTask)).thenThrow(new IllegalArgumentException());
         this.mockMvc.perform(post("/v1/tasks")
-                .contentType("application/json")
+                .contentType(JSON_CONTENT_TYPE)
                 .content(STUBBED_SUBMIT_JSON_REQUEST))
                 .andDo(print()).andExpect(status().isInternalServerError());
     }
 
     @Test
     void cancelTesTaskWhenRequestingIdReturnCanceledTask() throws Exception {
-        this.mockMvc.perform(post("/v1/tasks/{id}:cancel", STUBBED_TASK_ID))
+        when(tesTaskService.cancelTesTask(DEFAULT_TASK_ID)).thenReturn(new TesCancelTaskResponse());
+        this.mockMvc.perform(post("/v1/tasks/{id}:cancel", DEFAULT_TASK_ID))
                 .andDo(print()).andExpect(status().isOk());
+    }
+
+    @Test
+    void expectIllegalStateExceptionWhenRunCancelTesTaskWithWrongId() throws Exception {
+        when(tesTaskService.cancelTesTask(EMPTY_INPUT)).thenThrow(new IllegalStateException(messageHelper
+                .getMessage(MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, "taskId")));
+        this.mockMvc.perform(post("/v1/tasks/{id}:cancel", EMPTY_INPUT))
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().string(containsString(messageHelper
+                        .getMessage(MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, "taskId")
+                        + CANCEL_REQUEST_DESCRIPTION)));
     }
 
     @Test
@@ -93,4 +133,23 @@ public class TesAdapterControllerTest {
                 .andDo(print()).andExpect(status().isOk());
     }
 
+    @Test
+    void getTesTaskWhenRequestingReturnTesTaskResponse() throws Exception {
+        tesExecutor.setImage(DEFAULT_IMAGE);
+        tesExecutor.setCommand(Collections.singletonList(DEFAULT_COMMAND));
+        tesTask.setExecutors(Collections.singletonList(tesExecutor));
+        this.mockMvc.perform(get("/v1/tasks/{id}", DEFAULT_TASK_ID).contentType(JSON_CONTENT_TYPE))
+                .andDo(print()).andExpect(status().isOk()).andExpect(content()
+                .json(new ObjectMapper().writeValueAsString(tesTask)));
+    }
+
+    @Test
+    void serviceInfoRequestShouldReturnCurrentServiceState() throws Exception {
+        tesServiceInfo.setName(nameOfService);
+        tesServiceInfo.setDoc(doc);
+        tesServiceInfo.setStorage(new ArrayList<>());
+        this.mockMvc.perform(get("/v1/tasks/service-info").contentType(JSON_CONTENT_TYPE))
+                .andDo(print()).andExpect(status().isOk())
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(tesServiceInfo)));
+    }
 }

--- a/tes-adapter/src/test/java/com/epam/pipeline/tesadapter/service/TaskMapperTest.java
+++ b/tes-adapter/src/test/java/com/epam/pipeline/tesadapter/service/TaskMapperTest.java
@@ -91,7 +91,7 @@ class TaskMapperTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> taskMapper.getExecutorFromTesExecutorsList(tesExecutors));
         assertTrue(exception.getMessage().contains(messageHelper.getMessage(
-                MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, EXECUTORS, tesExecutors)));
+                MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, EXECUTORS)));
     }
 
     @ParameterizedTest
@@ -109,8 +109,8 @@ class TaskMapperTest {
         zones.add("Second zone");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> taskMapper.getProperRegionIdInCloudRegionsByTesZone(zones));
-        assertTrue(exception.getMessage().contains(messageHelper.getMessage(
-                MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, EXECUTORS, zones)));
+        assertEquals(exception.getMessage(), messageHelper.getMessage(
+                MessageConstants.ERROR_PARAMETER_INCOMPATIBLE_CONTENT, "zones"));
     }
 
     @Test


### PR DESCRIPTION
added more integration WebMvc tests to cover TesAdapterController class, refactored TesExceptionHandler, fixed message-outputs (changed name file from message.properties to messages.properties). Rise coverage for TesAdapterController to 100%. updated build.gradle to be able to use "jacoco".